### PR TITLE
Fix Woo_Posti_Shipping\Shipment class error

### DIFF
--- a/posti_shipping/classes/class-shipment.php
+++ b/posti_shipping/classes/class-shipment.php
@@ -13,13 +13,4 @@ class Shipment extends \Woo_Pakettikauppa_Core\Shipment {
 
     return $methods;
   }
-
-  public static function tracking_url( $tracking_code ) {
-    if ( empty($tracking_code) ) {
-      return '';
-    }
-    $tracking_url = 'https://www.posti.fi/fi/seuranta#/lahetys/' . $tracking_code;
-
-    return $tracking_url;
-  }
 }


### PR DESCRIPTION
The parent class requires the `tracking_url` method to be `tracking_url( $base_url, $tracking_code )` but since the tracking base url is now passed via config, the modified method is not needed anymore. 