### PR TITLE
EP-222: Remove test mode

### DIFF
--- a/core/class-core.php
+++ b/core/class-core.php
@@ -40,6 +40,7 @@ if ( ! class_exists(__NAMESPACE__ . '\Core') ) {
 
     public $api_config; // Used by Pakettikauppa\Client
     public $api_comment; // Used by ^
+    public $api_mode;
 
     public $order_pickup;
     public $order_pickup_url;
@@ -94,7 +95,8 @@ if ( ! class_exists(__NAMESPACE__ . '\Core') ) {
 
       $this->text = $this->load_text_class();
 
-      $this->api_config = $config['pakettikauppa_api_config'] ?? array();
+      $this->api_config = apply_filters('posti_api_configs', $config['pakettikauppa_api_config'] ?? array());
+      $this->api_mode = apply_filters('posti_api_mode', 'production');
       $this->api_comment = $config['pakettikauppa_api_comment'] ?? 'From WooCommerce';
 
       $this->order_pickup = $config['order_pickup'] ?? false;

--- a/core/class-shipment.php
+++ b/core/class-shipment.php
@@ -209,7 +209,8 @@ if ( ! class_exists(__NAMESPACE__ . '\Shipment') ) {
       } else {
         try {
           $configs = $this->core->api_config;
-          if ( ! empty($configs['production']['use_posti_auth']) ) {
+          $mode = $this->core->api_mode;
+          if ( ! empty($configs[$mode]['use_posti_auth']) ) {
             $token = $this->client->getToken();
             if ( empty($token) ) {
               $status['api_good'] = false;
@@ -816,7 +817,7 @@ if ( ! class_exists(__NAMESPACE__ . '\Shipment') ) {
 
       $account_number = isset($settings['account_number']) ? $settings['account_number'] : '';
       $secret_key     = isset($settings['secret_key']) ? $settings['secret_key'] : '';
-      $mode           = isset($settings['mode']) ? $settings['mode'] : 'test';
+      $mode           = $this->core->api_mode;
 
       if ( empty($this->config[$mode]) ) {
           $this->config[$mode] = array();
@@ -1721,9 +1722,8 @@ if ( ! class_exists(__NAMESPACE__ . '\Shipment') ) {
         // $this->settings = get_option('woocommerce_pakettikauppa_shipping_method_settings', array());
         if ( empty($this->settings) ) {
           $this->settings = array(
-            'mode' => 'test',
-            'account_number' => '00000000-0000-0000-0000-000000000000',
-            'secret_key' => '1234567890ABCDEF',
+            'account_number' => '',
+            'secret_key' => '',
             'pickup_points' => '',
             'sender_name' => get_bloginfo('name'),
             'sender_address' => get_option('woocommerce_store_address'),

--- a/core/class-shipping-method.php
+++ b/core/class-shipping-method.php
@@ -82,12 +82,10 @@ if ( ! class_exists(__NAMESPACE__ . '\Shipping_Method') ) {
       $shipping_method = $this->get_core()->shippingmethod;
       $field_pref = 'woocommerce_' . $shipping_method . '_';
       $configs = $this->get_core()->api_config;
-      if ( isset($_POST[$field_pref . 'mode']) ) {
-        $settings['mode'] = wc_clean($_POST[$field_pref . 'mode']);
+      if ( isset($_POST[$field_pref . 'account_number']) ) {
         $settings['account_number'] = sanitize_text_field($_POST[$field_pref . 'account_number']);
         $settings['secret_key'] = trim($_POST[$field_pref . 'secret_key']);
       }
-      $mode = $settings['mode'];
 
       wp_localize_script( // Passing values to JS instead of directly inserting into JS code
         $this->get_core()->prefix . '_admin_js',
@@ -117,26 +115,19 @@ if ( ! class_exists(__NAMESPACE__ . '\Shipping_Method') ) {
             },
             dataType: 'json'
           }).done(function( status ) {
-            <?php if ( $mode == 'production' ) : ?>
-              hide_mode_react(status.api_good);
-              if (status.api_good) {
-                show_api_notice("", false);
-              } else {
-                var msg = status.msg;
-                if (status.error) {
-                  msg += ".<br/><b><?php _e('Error', 'woo-pakettikauppa'); ?>:</b> " + status.error;
-                }
-                if (status.code) {
-                  msg += " <i>(<?php _e('Code', 'woo-pakettikauppa'); ?> " + status.code + ")</i>";
-                }
-                show_api_notice(msg, true);
+            hide_mode_react(status.api_good);
+            if (status.api_good) {
+              show_api_notice("", false);
+            } else {
+              var msg = status.msg;
+              if (status.error) {
+                msg += ".<br/><b><?php _e('Error', 'woo-pakettikauppa'); ?>:</b> " + status.error;
               }
-            <?php endif; ?>
-          });
-
-          $( document ).on("change", "#woocommerce_pakettikauppa_shipping_method_mode", function() {
-            hide_mode_react();
-            show_api_notice("", false);
+              if (status.code) {
+                msg += " <i>(<?php _e('Code', 'woo-pakettikauppa'); ?> " + status.code + ")</i>";
+              }
+              show_api_notice(msg, true);
+            }
           });
         });
 
@@ -437,13 +428,6 @@ if ( ! class_exists(__NAMESPACE__ . '\Shipping_Method') ) {
       return $html;
     }
 
-    protected function get_form_field_mode() {
-      return array(
-        'type'    => 'hidden',
-        'default' => 'production',
-      );
-    }
-
     public function generate_hidden_html( $key, $args )
     {
       $field_key = $this->get_field_key($key);
@@ -464,8 +448,6 @@ if ( ! class_exists(__NAMESPACE__ . '\Shipping_Method') ) {
           'type'  => 'title',
           'class' => 'hidden',
         ),
-
-        'mode'                       => $this->get_form_field_mode(),
 
         'account_number'             => array(
           'title'    => $this->get_core()->text->api_key_title(),

--- a/posti-shipping.php
+++ b/posti-shipping.php
@@ -79,11 +79,6 @@ $instance = new Woo_Posti_Shipping(
         'use_posti_auth' => true,
         'posti_auth_url' => 'https://oauth.posti.com',
       ],
-      'test' => [
-        'base_uri' => 'https://nextshipping.posti.fi',
-        'use_posti_auth' => true,
-        'posti_auth_url' => 'https://oauth.posti.com',
-      ], 
     ], // Overrides defaults and UI settings
     'tracking_base_url' => 'https://www.posti.fi/fi/seuranta#/lahetys/',
     'order_pickup' => true, //enable or disable order pickup feature


### PR DESCRIPTION
Added new WP filters that allow to use specific API configs and mode on website:
_Add new configs:_
```
add_filter('posti_api_configs', function($configs) {
        $configs['test'] = array(
            'base_uri' => 'https://test.fi',
            'use_posti_auth' => true,
            'posti_auth_url' => 'https://test.fi',
        );
        return $configs;
});
```
_Use specific configs:_
```
add_filter('posti_api_mode', function($mode) { return 'test'; });
```