### PR TITLE
Fix: Avoid session_start() warning on PHP-FPM / cPanel environments

### DIFF
--- a/core/class-admin.php
+++ b/core/class-admin.php
@@ -103,9 +103,12 @@ if ( ! class_exists(__NAMESPACE__ . '\Admin') ) {
     }
 
     public function add_admin_notice( $msg, $type ) {
-      if ( ! session_id() ) {
-        session_start();
-      }
+	    if (session_status() === PHP_SESSION_NONE) {
+	    if (!is_dir(ini_get('session.save_path'))) {
+	        ini_set('session.save_path', '/var/cpanel/php/sessions/ea-php82');
+	    }
+	    session_start();
+	}
       if ( ! isset($_SESSION['pakettikauppa_notices']) ) {
         $_SESSION['pakettikauppa_notices'] = array();
       }


### PR DESCRIPTION
- Checks if session is not already active before calling session_start()
- Verifies that session.save_path exists, and sets a fallback path if missing
- Prevents session_start() warnings on EA-PHP 8.x with PHP-FPM and CloudLinux
- Improves compatibility in shared hosting environments commonly used with cPanel

Tested on EA-PHP 8.2 with WordPress + WooCommerce