### PR TITLE
Check WooCommerce 10.7.0 compatibility

### DIFF
--- a/core/class-core.php
+++ b/core/class-core.php
@@ -100,7 +100,7 @@ if ( ! class_exists(__NAMESPACE__ . '\Core') ) {
       $this->api_comment = $config['pakettikauppa_api_comment'] ?? 'From WooCommerce';
 
       $this->order_pickup = $config['order_pickup'] ?? false;
-      $this->order_pickup_url = $config['order_pickup_callback_url'] ?? false;
+      $this->order_pickup_url = apply_filters('posti_pickup_callback_url', $config['order_pickup_callback_url'] ?? false);
 
       self::$instance = $this;
 

--- a/core/class-manifest.php
+++ b/core/class-manifest.php
@@ -388,6 +388,7 @@ if ( ! class_exists(__NAMESPACE__ . '\Manifest') ) {
                                 'post_status' => 'closed',
                               )
                             );
+                            update_post_meta($id, $this->core->prefix . '_manifest_pickup_time', $date . ' ' . $time_from . ' - ' . $time_to);
                               //make orders complete
                               $current_orders = get_post_meta($id, $this->core->prefix . '_manifest_orders', true);
                               foreach ( $current_orders as $order_id ) {

--- a/posti-shipping.php
+++ b/posti-shipping.php
@@ -13,7 +13,7 @@
  * Requires at least: 5.0
  * Tested up to: 6.9.4
  * WC requires at least: 4.7
- * WC tested up to: 9.9.7
+ * WC tested up to: 10.7.0
  * Requires PHP: 7.1
  *
  * Copyright: © 2017-2019 Seravo Oy, 2020-2026 Posti Oy


### PR DESCRIPTION
- Compatibility tested on WP 6.9.4 WC 10.7.0
- Fixed the display of "Pickup time" in the table on the "Pickup Orders" page
- Added a new filter to change the pickup callback URL:
```php
add_filter('posti_pickup_callback_url',  function($url) {
    return is_string($url) ? $url : false; // Any logic that returns string or false
});
```