### PR TITLE
EP-312: Remove "Sender ID" field

### DIFF
--- a/core/class-manifest.php
+++ b/core/class-manifest.php
@@ -416,7 +416,7 @@ if ( ! class_exists(__NAMESPACE__ . '\Manifest') ) {
             $xml->addAttribute('xmlns', 'http://api.posti.fi/xml/POSTRA/1');
 
             $header = $xml->addChild('Header');
-            $header->addChild('SenderId', $settings['order_pickup_sender_id']);
+            $header->addChild('SenderId', 'WOOPLUGIN');
             $header->addChild('ReceiverId', '003715318644');
             $header->addChild('DocumentDateTime', gmdate('c'));
             $header->addChild('Sequence', floor(microtime(true) * 1000));

--- a/core/class-shipping-method.php
+++ b/core/class-shipping-method.php
@@ -490,14 +490,6 @@ if ( ! class_exists(__NAMESPACE__ . '\Shipping_Method') ) {
           'desc_tip' => true,
         ),
 
-        'order_pickup_sender_id'                 => array(
-          'title'    => $this->get_core()->text->sender_id_title(),
-          'desc'     => '',
-          'type'     => 'text',
-          'default'  => '',
-          'desc_tip' => true,
-        ),
-
         'pickup_points'              => array(
           'title' => $this->get_core()->text->pickup_points_title(),
           'type'  => 'pickuppoints',
@@ -765,7 +757,6 @@ if ( ! class_exists(__NAMESPACE__ . '\Shipping_Method') ) {
           unset($fields['order_pickup']);
           unset($fields['order_pickup_customer_id']);
           unset($fields['order_pickup_invoice_id']);
-          unset($fields['order_pickup_sender_id']);
       }
       if ( get_option($this->get_core()->prefix . '_wizard_done') == 1 ) {
         $fields['setup_wizard'] = array(

--- a/core/class-text.php
+++ b/core/class-text.php
@@ -271,10 +271,6 @@ if ( ! class_exists(__NAMESPACE__ . '\Text') ) {
       return __('Invoice ID', 'woo-pakettikauppa');
     }
 
-    public function sender_id_title() {
-      return __('Sender ID', 'woo-pakettikauppa');
-    }
-
     public function shipping_settings_title() {
       return __('Shipping settings', 'woo-pakettikauppa');
     }


### PR DESCRIPTION
- Removed "Sender ID" parameter from plugin settings.
- The "SenderId" parameter in the POSTRA request is set to the static value "WOOPLUGIN".