### PR TITLE
Allow admin pickup point search by custom address regardless of checkout override setting

### DIFF
--- a/core/class-admin.php
+++ b/core/class-admin.php
@@ -1452,7 +1452,13 @@ if ( ! class_exists(__NAMESPACE__ . '\Admin') ) {
       $method_code = sanitize_text_field($_POST['method']);
       $custom_address = sanitize_text_field($_POST['address']);
       $type = (isset($_POST['type'])) ? sanitize_text_field($_POST['type']) : null;
-      $pickup_points = $this->get_pickup_points_for_method($method_code, null, null, null, $custom_address, $type);
+      try {
+        // Admin-only search, unlike checkout, so it always searches by
+        // custom address regardless of show_pickup_point_override_query.
+        $pickup_points = $this->shipment->get_pickup_points_by_free_input($custom_address, $method_code, $type);
+      } catch ( \Exception $e ) {
+        $pickup_points = 'error-zip';
+      }
       if ( $pickup_points == 'error-zip' ) {
         echo $pickup_points;
       } else {


### PR DESCRIPTION
## Summary
- The order admin metabox pickup point search always returned an empty result when `show_pickup_point_override_query` was set to `no`, because that checkout-facing setting also gated the admin-only AJAX search (`get_pickup_point_by_custom_address`).
- This handler is registered only via `wp_ajax_` (never `wp_ajax_nopriv_`), so it's safe for it to always search by custom address, independent of the checkout override setting.
- `get_pickup_points_for_method()` is left unchanged for its other call sites (initial metabox render), which still respect the setting for postcode-based lookups.

## Test plan
- [x] Verified locally: with `show_pickup_point_override_query` set to `no`, typing an address in the order admin pickup search field now returns pickup points instead of an empty result.
- [x] Confirm checkout/frontend pickup point behavior is unaffected (unchanged code paths).

Fixes #181