### PR TITLE
EP-340: PR #189 Review - Remove double escape and add classes

### DIFF
--- a/templates/posti/thank-you-pickup-point.php
+++ b/templates/posti/thank-you-pickup-point.php
@@ -13,5 +13,7 @@ if ( ! defined('ABSPATH') ) {
 }
 ?>
 
-<h2><?php esc_html_e('Pickup point', 'woo-pakettikauppa'); ?></h2>
-<p><?php echo esc_html($pickup_point); ?></p>
+<div class="woocommerce-order-details__pickup-point posti-thank-you-pickup-point">
+  <h2 class="wp-block-heading"><?php esc_html_e('Pickup point', 'woo-pakettikauppa'); ?></h2>
+  <p><?php echo esc_html($pickup_point); ?></p>
+</div>

--- a/templates/posti/thank-you-pickup-point.php
+++ b/templates/posti/thank-you-pickup-point.php
@@ -15,5 +15,5 @@ if ( ! defined('ABSPATH') ) {
 
 <div class="woocommerce-order-details__pickup-point posti-thank-you-pickup-point">
   <h2 class="wp-block-heading"><?php esc_html_e('Pickup point', 'woo-pakettikauppa'); ?></h2>
-  <p><?php echo esc_html($pickup_point); ?></p>
+  <p><?php echo $pickup_point; ?></p>
 </div>


### PR DESCRIPTION
- During testing, a problem was found that `class-frontend.php:638` already escaped the pickup point value, so another escape used in the template could corrupt the string if it contained special characters.
- The elements in the template have been added into a `<div>` and classes have been added so that clients can more easily customize the design of this block according to their theme.