### PR TITLE
EP-337: Checked working on WP 7.1 and WC 11.0

### DIFF
--- a/posti-shipping.php
+++ b/posti-shipping.php
@@ -11,9 +11,9 @@
  * License: GPL v3 or later
  *
  * Requires at least: 5.0
- * Tested up to: 7.0
+ * Tested up to: 7.1
  * WC requires at least: 4.7
- * WC tested up to: 10.7.0
+ * WC tested up to: 11.0.1
  * Requires PHP: 7.1
  *
  * Copyright: © 2017-2019 Seravo Oy, 2020-2026 Posti Oy


### PR DESCRIPTION
No problems detected, everything works on Wordpress 7.1 with WooCommerce 11.0.1
The system logs only show deprecated functions in the Pakettikauppa library, but this requires fixing the library itself:
```html
[28-Aug-2026 12:21:11 UTC] PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /wp-content/plugins/posti-shipping/vendor/pakettikauppa/api-library/src/Pakettikauppa/Shipment/Sender.php on line 123
[28-Aug-2026 12:21:11 UTC] PHP Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in /wp-content/plugins/posti-shipping/vendor/pakettikauppa/api-library/src/Pakettikauppa/Shipment/Receiver.php on line 85
``` 